### PR TITLE
back to the future

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ RUN wget -O /bin/drake https://raw.githubusercontent.com/Factual/drake/3659c1167
     chmod 755 /bin/drake
 
 WORKDIR /
-RUN wget https://github.com/dssg/acs2pgsql/archive/d25c8dc7c231645f70a36b4e1fd4466c7e9a8ed1.zip && \
-    unzip d25c8dc7c231645f70a36b4e1fd4466c7e9a8ed1.zip
-COPY default_profile /acs2pgsql-d25c8dc7c231645f70a36b4e1fd4466c7e9a8ed1/
+RUN wget https://github.com/dssg/acs2pgsql/archive/kit_acs_2016.zip && \
+    unzip kit_acs_2016.zip
+COPY default_profile /acs2pgsql-kit_acs_2016/
 
-WORKDIR /acs2pgsql-d25c8dc7c231645f70a36b4e1fd4466c7e9a8ed1
+WORKDIR /acs2pgsql-kit_acs_2016
 ENTRYPOINT ["/bin/drake", "--auto"]

--- a/Drakefile
+++ b/Drakefile
@@ -24,7 +24,7 @@ SQL_DIR:=psql/
 data/census-postgres/ <- [-timecheck]
      git clone https://github.com/censusreporter/census-postgres.git $OUTPUT
 
-$(for y in {2009..2015}; do
+$(for y in {2009..2016}; do
 
 # download and unzip the acs tract and block group data
 echo "URL=\"http://www2.census.gov/programs-surveys/acs/summary_file/"$y"/data/5_year_by_state/$[STATE]_Tracts_Block_Groups_Only.zip\""


### PR DESCRIPTION
2016 ACS data is now available, so drakefile loop should include it. Also, edit dockerfile to download from this git branch rather than old commit (note: will likely want to change that to `master` before merging!)